### PR TITLE
Update CODEOWNERS to 2020 Developers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # https://git-scm.com/docs/gitignore#_pattern_format
 
 # All files
-*   @Computerization/2019-core
+*   @Computerization/2020-Dev


### PR DESCRIPTION
Refer to documentations [About code owners](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) and [About required reviews for pull requests](https://docs.github.com/en/github/administering-a-repository/about-required-reviews-for-pull-requests) for why this change is made